### PR TITLE
add aangewezen burgemeester bestuursfunctie code

### DIFF
--- a/bestuursfunctie-code-uuid.ttl
+++ b/bestuursfunctie-code-uuid.ttl
@@ -42,4 +42,5 @@
 <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/8c91c321ad477c4fc372ee36358d3ed4> <http://mu.semte.ch/vocabularies/core/uuid> "8c91c321ad477c4fc372ee36358d3ed4" .
 <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/e2af0ea1a6af96cfb698ac39ad985eea> <http://mu.semte.ch/vocabularies/core/uuid> "e2af0ea1a6af96cfb698ac39ad985eea" .
 <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/f848fa3cc2c5fb7c581a116866293925> <http://mu.semte.ch/vocabularies/core/uuid> "f848fa3cc2c5fb7c581a116866293925" .
+<http://data.vlaanderen.be/id/concept/BestuursfunctieCode/7b038cc40bba10bec833ecfe6f15bc7a> <http://mu.semte.ch/vocabularies/core/uuid> "7b038cc40bba10bec833ecfe6f15bc7a" .
 <http://data.vlaanderen.be/id/conceptscheme/BestuursfunctieCode> <http://mu.semte.ch/vocabularies/core/uuid> "673a47c84faee6c21da8ce447ce5710a" .

--- a/local-politician-concept-scheme.ttl
+++ b/local-politician-concept-scheme.ttl
@@ -36,6 +36,10 @@ lblod:LocalPoliticianMandateRole rdf:type skos:ConceptScheme ;
 <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000013> skos:topConceptOf lblod:LocalPoliticianMandateRole ;
   skos:inScheme lblod:LocalPoliticianMandateRole .
 
+# skos:prefLabel "Aangewezen Burgemeester"
+<http://data.vlaanderen.be/id/concept/BestuursfunctieCode/7b038cc40bba10bec833ecfe6f15bc7a> skos:topConceptOf lblod:LocalPoliticianMandateRole ;
+  skos:inScheme lblod:LocalPoliticianMandateRole .
+
 #  skos:prefLabel "Schepen" ;
 <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/5ab0e9b8a3b2ca7c5e000014> skos:topConceptOf lblod:LocalPoliticianMandateRole ;
   skos:inScheme lblod:LocalPoliticianMandateRole .


### PR DESCRIPTION
This adds the aangewezen burgemeester bestuursfunctie code.

The URI can already be found in centrale vindplaats: https://centrale-vindplaats.lblod.info/sparql

With the query:

```
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
PREFIX ext: <http://mu.semte.ch/vocabularies/ext/>
PREFIX adms: <http://www.w3.org/ns/adms#>
 SELECT DISTINCT *
WHERE {
  GRAPH ?g {
     <http://data.vlaanderen.be/id/concept/BestuursfunctieCode/7b038cc40bba10bec833ecfe6f15bc7a> ?p ?o.
  }
} limit 100
```

So this PR is a bit out of order, but at least now the code list is updated too.